### PR TITLE
Add delete device capability for backend api

### DIFF
--- a/backend/api/tests/test_views.py
+++ b/backend/api/tests/test_views.py
@@ -115,3 +115,14 @@ class DeviceViewTestCase(TestCase):
     def test_api_can_create_a_device(self):
         """Test the api has device creation capability."""
         self.assertEqual(self.response.status_code, status.HTTP_201_CREATED)
+
+    def test_api_can_delete_a_device(self):
+        """Test the api can delete a device."""
+        device = Device.objects.get()
+        response = self.client.delete(
+            reverse('device_details', kwargs={'pk': device.id}),
+            format='json',
+            follow=True)
+
+        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -5,6 +5,7 @@ from .views import (
                 CompanyRetrieveUpdateDestroyView,
                 DeviceModelListCreateView,
                 DeviceListCreateView,
+                DeviceRetrieveUpdateDestroyView,
             )
 
 urlpatterns =[
@@ -12,6 +13,7 @@ urlpatterns =[
     path('companies/<int:pk>', CompanyRetrieveUpdateDestroyView.as_view(), name="details"),
     path('device_models/', DeviceModelListCreateView.as_view(), name="create_device_model"),
     path('devices/', DeviceListCreateView.as_view(), name="create_device"),
+    path('devices/<int:pk>', DeviceRetrieveUpdateDestroyView.as_view(), name="device_details"),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -97,3 +97,14 @@ class DeviceListCreateView(APIView):
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+class DeviceRetrieveUpdateDestroyView(APIView):
+    """This class handles the http GET, PUT and DELETE requests."""
+
+    def delete(self, request, pk, format=None):
+        """Delete a single device record."""
+        device = Device.objects.get(pk=pk)
+        device.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+


### PR DESCRIPTION
A device can now be deleted throught:

`DELETE api/devices/<id>`